### PR TITLE
Enable static and dynamic http compression on CF

### DIFF
--- a/fixtures/windows_app/Content/Site.css
+++ b/fixtures/windows_app/Content/Site.css
@@ -1,0 +1,24 @@
+﻿body {
+    padding-top: 50px;
+    padding-bottom: 20px;
+}
+
+/* Set padding to keep content from hitting the edges */
+.body-content {
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+/* Override the default bootstrap behavior where horizontal description lists 
+   will truncate terms that are too long to fit in the left column 
+*/
+.dl-horizontal dt {
+    white-space: normal;
+}
+
+/* Set width on the form input elements since they're 100% wide by default */
+input,
+select,
+textarea {
+    max-width: 280px;
+}


### PR DESCRIPTION
This PR adds static and dynamic http compression for apps running on Windows cell.  This features is working as of [HWC version 12.0.0](https://github.com/cloudfoundry/hwc/releases/tag/12.0.0) and works on both `windows2016` and `windows2012R2` stack.