### PR TITLE
Change default version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 language: hwc
 default_versions:
 - name: hwc
-  version: 20.0.0
+  version: 21.0.0
 dependencies:
 - name: hwc
   version: 21.0.0


### PR DESCRIPTION
Changes to match the new version of HWC now included in the buildpack: 21.0.0.