### PR TITLE
remove references to the windows2016 stack

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "stack": "windows2016",
+  "stack": "windows",
   "oses": [
     "windows"
   ],

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,6 @@ dependencies:
   uri: https://buildpacks.cloudfoundry.org/dependencies/hwc/hwc_27.0.0_windows_x86-64_any-stack_4c27dcc4.zip
   sha256: 4c27dcc409a4ec087953bf99ec02ba7da72805cf56120a424498060f8caec6dd
   cf_stacks:
-  - windows2016
   - windows
   source: https://github.com/cloudfoundry/hwc/archive/27.0.0.tar.gz
   source_sha256: 8242c0d22c906340204cabc457df33896493abc4360056bc68dfca09db984cb5


### PR DESCRIPTION
This stack is identical to the windows stack and windows2016 has been unsupported in CF for a long time now.
https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html#-available-stacks